### PR TITLE
fix: add a visible focus ring to the logo link

### DIFF
--- a/src/App.vue
+++ b/src/App.vue
@@ -18,7 +18,10 @@ useHead({
     <UApp>
       <UHeader>
         <template #left>
-          <RouterLink to="/">
+          <RouterLink
+            to="/"
+            class="focus-visible:outline-3 outline-primary/25 rounded-md p-1 -ms-1"
+          >
             <AppLogo class="w-auto h-6 shrink-0" />
           </RouterLink>
 


### PR DESCRIPTION
The logo link had no focus style of its own, so tabbing to it fell back to the browser default. Adds the same treatment already shipping in `docs` and `calendar`:

```
focus-visible:outline-3 outline-primary/25 rounded-md p-1 -ms-1
```

`p-1 -ms-1` gives the outline room to breathe without shifting the logo.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Improved the home navigation link with a visible keyboard-focus outline.
  * Updated the link’s primary outline color, rounded corners, and spacing for a clearer, more polished appearance.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->